### PR TITLE
Add context-engine-ai to Long-term memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Image source: https://blog.langchain.com/context-engineering-for-agents/
 - [A-mem](https://github.com/agiresearch/A-mem) (`agiresearch`) ![](https://img.shields.io/github/stars/agiresearch/A-mem.svg?style=social) A-MEM: Agentic Memory for LLM Agents
 - [MemoryOS](https://github.com/BAI-LAB/MemoryOS) (`BAI-LAB`) ![](https://img.shields.io/github/stars/BAI-LAB/MemoryOS.svg?style=social) A memory operation system for personalized AI
 - [core](https://github.com/RedPlanetHQ/core) (`RedPlanetHQ`) ![](https://img.shields.io/github/stars/RedPlanetHQ/core.svg?style=social) Your personal plug and play memory layer for LLMs
+- [context-engine-ai](https://github.com/Quinnod345/context-engine) (`Quinnod345`) ![](https://img.shields.io/github/stars/Quinnod345/context-engine.svg?style=social) Lightweight context engine for AI agents — ingest events, build semantic context, query with natural language. Zero config with SQLite + local TF-IDF embeddings.
 
 ## 🔎 Select Context
 


### PR DESCRIPTION
## Summary

Adds [context-engine-ai](https://github.com/Quinnod345/context-engine) to the **Write Context > Long-term memory** section.

**context-engine-ai** is a lightweight context engine for AI agents:
- Ingest events from any source
- Query with natural language
- Ranked, time-decayed results
- Zero config default — SQLite + local TF-IDF embeddings (no API keys required)
- Optional pgvector + OpenAI embeddings for production

**npm:** [context-engine-ai](https://www.npmjs.com/package/context-engine-ai)
**GitHub:** [Quinnod345/context-engine](https://github.com/Quinnod345/context-engine)

```bash
npx context-engine-ai demo  # try it in 10 seconds
```