### PR TITLE
Add Cog to Long-term memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Image source: https://blog.langchain.com/context-engineering-for-agents/
 - [A-mem](https://github.com/agiresearch/A-mem) (`agiresearch`) ![](https://img.shields.io/github/stars/agiresearch/A-mem.svg?style=social) A-MEM: Agentic Memory for LLM Agents
 - [MemoryOS](https://github.com/BAI-LAB/MemoryOS) (`BAI-LAB`) ![](https://img.shields.io/github/stars/BAI-LAB/MemoryOS.svg?style=social) A memory operation system for personalized AI
 - [core](https://github.com/RedPlanetHQ/core) (`RedPlanetHQ`) ![](https://img.shields.io/github/stars/RedPlanetHQ/core.svg?style=social) Your personal plug and play memory layer for LLMs
+- [Cog](https://github.com/marciopuga/cog) (`marciopuga`) ![](https://img.shields.io/github/stars/marciopuga/cog.svg?style=social) A cognitive architecture for Claude Code that provides persistent memory via plain-text markdown conventions. Zettelkasten-inspired with four memory speeds (fragments, threads, webs, indexes). Zero dependencies.
 
 ## 🔎 Select Context
 


### PR DESCRIPTION
## Summary
- Adds [Cog](https://github.com/marciopuga/cog) to the Long-term memory section. Cog is a cognitive architecture for Claude Code that provides persistent memory via plain-text markdown conventions. Zettelkasten-inspired with four memory speeds (fragments, threads, webs, indexes). Zero dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)