### PR TITLE
Add Hindsight - AI agent memory by Vectorize

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Image source: https://blog.langchain.com/context-engineering-for-agents/
 - [A-mem](https://github.com/agiresearch/A-mem) (`agiresearch`) ![](https://img.shields.io/github/stars/agiresearch/A-mem.svg?style=social) A-MEM: Agentic Memory for LLM Agents
 - [MemoryOS](https://github.com/BAI-LAB/MemoryOS) (`BAI-LAB`) ![](https://img.shields.io/github/stars/BAI-LAB/MemoryOS.svg?style=social) A memory operation system for personalized AI
 - [core](https://github.com/RedPlanetHQ/core) (`RedPlanetHQ`) ![](https://img.shields.io/github/stars/RedPlanetHQ/core.svg?style=social) Your personal plug and play memory layer for LLMs
+- [hindsight](https://github.com/vectorize-io/hindsight) (`vectorize-io`) ![](https://img.shields.io/github/stars/vectorize-io/hindsight.svg?style=social) State-of-the-art long-term memory for AI agents by Vectorize. Open source, self-hostable, with integrations for LangChain, CrewAI, Claude Code, and more.
 
 ## 🔎 Select Context
 


### PR DESCRIPTION
## Summary
- Adds [Hindsight](https://github.com/vectorize-io/hindsight) to the **Long-term memory** section under Write Context.
- Hindsight is a state-of-the-art, MIT-licensed, open-source long-term memory system for AI agents by Vectorize. It can run fully self-hosted and integrates with LangChain, LlamaIndex, CrewAI, Claude Code, Vercel AI SDK, and many more.
- Fits naturally alongside existing memory tools like mem0, Letta, and Graphiti.