### PR TITLE
Add Akephalos

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Image source: https://blog.langchain.com/context-engineering-for-agents/
 - [memobase](https://github.com/memodb-io/memobase) (`memodb-io`) ![](https://img.shields.io/github/stars/memodb-io/memobase.svg?style=social) Profile-Based Long-Term Memory for AI Applications. Memobase handles user profiles, memory events, and evolving context
 - [A-mem](https://github.com/agiresearch/A-mem) (`agiresearch`) ![](https://img.shields.io/github/stars/agiresearch/A-mem.svg?style=social) A-MEM: Agentic Memory for LLM Agents
 - [MemoryOS](https://github.com/BAI-LAB/MemoryOS) (`BAI-LAB`) ![](https://img.shields.io/github/stars/BAI-LAB/MemoryOS.svg?style=social) A memory operation system for personalized AI
+- [Akephalos](https://github.com/sunnja69/akephalos) (`sunnja69`) ![](https://img.shields.io/github/stars/sunnja69/akephalos.svg?style=social) Local-first, markdown-first `.akephalos` passport for portable agent preferences, tool notes, rules, project context, and durable memories across agents/tools and machines via plain files/Git.
 - [core](https://github.com/RedPlanetHQ/core) (`RedPlanetHQ`) ![](https://img.shields.io/github/stars/RedPlanetHQ/core.svg?style=social) Your personal plug and play memory layer for LLMs
 
 ## 🔎 Select Context


### PR DESCRIPTION
Adds Akephalos to the long-term memory section. It is a local-first, markdown-first `.akephalos` passport for portable agent preferences, tool notes, rules, project context, and durable memories across agents/tools and machines via plain files/Git.

Repo/tag verified: https://github.com/sunnja69/akephalos, tag `v0.1.0`.