### PR TITLE
Add Vestige to Write Context > Long-term memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Image source: https://blog.langchain.com/context-engineering-for-agents/
 - [A-mem](https://github.com/agiresearch/A-mem) (`agiresearch`) ![](https://img.shields.io/github/stars/agiresearch/A-mem.svg?style=social) A-MEM: Agentic Memory for LLM Agents
 - [MemoryOS](https://github.com/BAI-LAB/MemoryOS) (`BAI-LAB`) ![](https://img.shields.io/github/stars/BAI-LAB/MemoryOS.svg?style=social) A memory operation system for personalized AI
 - [core](https://github.com/RedPlanetHQ/core) (`RedPlanetHQ`) ![](https://img.shields.io/github/stars/RedPlanetHQ/core.svg?style=social) Your personal plug and play memory layer for LLMs
+- [vestige](https://github.com/samvallad33/vestige) (`samvallad33`) ![](https://img.shields.io/github/stars/samvallad33/vestige.svg?style=social) Local-first cognitive memory MCP server for AI coding agents. Rust single binary, SQLite storage, FSRS-6 retention scheduling, active forgetting, hybrid keyword and vector retrieval.
 
 ## 🔎 Select Context
 


### PR DESCRIPTION
Adds Vestige to the Write Context > Long-term memory list.

Vestige is a local-first cognitive memory MCP server for AI coding agents. It is written in Rust and ships as a single binary, stores memory in local SQLite, and uses FSRS-6 retention scheduling, prediction-error gating on writes, active forgetting, and hybrid keyword plus vector retrieval. It speaks MCP over stdio and works with Claude Code, Cursor, VS Code, Codex, Windsurf, and JetBrains.

- Repo: https://github.com/samvallad33/vestige
- npm: vestige-mcp-server
- License: AGPL-3.0

The entry follows the existing format in that section: link, owner in backticks, GitHub stars badge, one-line description. One line added, no other changes.